### PR TITLE
[FIX] 0818 피드백 내용 수정

### DIFF
--- a/src/main/java/com/won/myongjiCamp/controller/api/ApplicationApiController.java
+++ b/src/main/java/com/won/myongjiCamp/controller/api/ApplicationApiController.java
@@ -5,6 +5,7 @@ import com.won.myongjiCamp.model.Member;
 import com.won.myongjiCamp.model.application.Application;
 import com.won.myongjiCamp.model.application.ApplicationFinalStatus;
 import com.won.myongjiCamp.model.application.ApplicationStatus;
+import com.won.myongjiCamp.model.board.CompleteBoard;
 import com.won.myongjiCamp.model.board.RecruitBoard;
 import com.won.myongjiCamp.model.board.RecruitStatus;
 import com.won.myongjiCamp.model.board.role.Role;
@@ -68,7 +69,7 @@ public class ApplicationApiController {
     public Result listOfWriter(@AuthenticationPrincipal PrincipalDetail principal) {
         List<RecruitBoard> boards = applicationService.listOfWriter(principal.getMember());
         List<ApplicationResponseDto> collect = boards.stream()
-                .map(b -> new ApplicationResponseDto(b.getId(), principal.getMember().getId(), applicationRepository.countByBoard(b), b.getTitle(), b.getStatus(), b.getCreatedDate()))
+                .map(b -> new ApplicationResponseDto((CompleteBoard) b.getWriteCompleteBoard(), b.getId(), principal.getMember().getId(), applicationRepository.countByBoard(b), b.getTitle(), b.getStatus(), b.getCreatedDate()))
                 .collect(Collectors.toList());
         return new Result(collect);
     }
@@ -135,16 +136,19 @@ public class ApplicationApiController {
         private String nickname;
         private String applyContent;
         private String resultContent;
-
+        private Long completeBoardId;
 
         //모집자 입장에서의 지원 확인 (지원현황)
-        public ApplicationResponseDto(Long boardId, Long memberId, Long num, String boardTitle, RecruitStatus recruitStatus, Timestamp boardcreatedDate) {
+        public ApplicationResponseDto(CompleteBoard completeBoard, Long boardId, Long memberId, Long num, String boardTitle, RecruitStatus recruitStatus, Timestamp boardcreatedDate) {
             this.boardId = boardId;
             this.memberId = memberId;
             this.num = num;
             this.boardTitle = boardTitle;
             this.boardcreatedDate = boardcreatedDate;
             this.recruitStatus = recruitStatus;
+            if (completeBoard != null){
+                this.completeBoardId = completeBoard.getId();
+            }
         }
 
         //지원자 입장에서의 지원 확인 (지원현황)

--- a/src/main/java/com/won/myongjiCamp/controller/api/BoardApiController.java
+++ b/src/main/java/com/won/myongjiCamp/controller/api/BoardApiController.java
@@ -6,6 +6,7 @@ import com.won.myongjiCamp.dto.ResponseDto;
 import com.won.myongjiCamp.dto.RoleAssignmentDto;
 import com.won.myongjiCamp.dto.request.CompleteDto;
 import com.won.myongjiCamp.dto.request.BoardSearchDto;
+import com.won.myongjiCamp.model.application.Application;
 import com.won.myongjiCamp.model.board.*;
 import com.won.myongjiCamp.model.board.role.Role;
 import com.won.myongjiCamp.model.board.role.RoleAssignment;
@@ -134,6 +135,17 @@ public class BoardApiController {
                 .orElseThrow(()->new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
 
         return new Result(new DetailCompleteResponseDto(board));
+    }
+
+    // 내가 작성한 complete 게시글 목록
+    @GetMapping("/api/auth/complete/writer")
+    public Result getMemberComplete(@AuthenticationPrincipal PrincipalDetail principalDetail){
+
+        List<CompleteBoard> boards = boardService.listMemberComplete(principalDetail.getMember());
+        List<MemberCompleteBoardListResponseDto> collect = boards.stream()
+                .map(b -> new MemberCompleteBoardListResponseDto(b))
+                .collect(Collectors.toList());
+        return new Result(collect);
     }
 
 
@@ -269,6 +281,25 @@ public class BoardApiController {
             for(Image image : completeBoard.getImages()){
                 this.imageUrls.add(image.getUrl());
             }
+        }
+    }
+
+    @Data
+    public class MemberCompleteBoardListResponseDto {
+        private Long boardId;
+        private String title;
+        private Timestamp modifiedDate;
+        private Timestamp createdDate;
+        private int commentCount;
+        private int scrapCount;
+
+        public MemberCompleteBoardListResponseDto(Board board) {
+            this.boardId = board.getId();
+            this.title = board.getTitle();
+            this.modifiedDate = board.getModifiedDate();
+            this.createdDate = board.getCreatedDate();
+            this.commentCount = board.getCommentCount();
+            this.scrapCount = board.getScrapCount();
         }
     }
 }

--- a/src/main/java/com/won/myongjiCamp/controller/api/BoardApiController.java
+++ b/src/main/java/com/won/myongjiCamp/controller/api/BoardApiController.java
@@ -62,11 +62,11 @@ public class BoardApiController {
         return new ResponseDto<String>(HttpStatus.OK.value(), "게시글이 삭제되었습니다.");
     }
 
-    // complete 게시글 작성
-    @PostMapping("/api/auth/complete")
-    public Result createComplete(@ModelAttribute @Valid CompleteDto completeDto, @AuthenticationPrincipal PrincipalDetail principalDetail) throws IOException {
+    // complete 게시글 작성, id는 모집완료 글 id
+    @PostMapping("/api/auth/complete/{id}")
+    public Result createComplete(@ModelAttribute @Valid CompleteDto completeDto, @AuthenticationPrincipal PrincipalDetail principalDetail, @PathVariable long id) throws IOException {
 
-        CompleteService.WriteCompleteResponseDto writeCompleteResponseDto = completeService.create(completeDto, principalDetail.getMember());
+        CompleteService.WriteCompleteResponseDto writeCompleteResponseDto = completeService.create(completeDto, principalDetail.getMember(), id);
 
         return new Result(writeCompleteResponseDto);
     }
@@ -159,6 +159,7 @@ public class BoardApiController {
         private Integer profileIcon; // 글 쓴 사람 아이콘
         private Timestamp modifiedDate;//수정한 날짜
         private Timestamp createdDate; //만든 날짜
+        private Long completeBoardId; //개발 완료 글 id
 
         public DetailRecruitResponseDto(RecruitBoard recruitBoard,List<RoleAssignmentDto> roleAssignmentDtoList){
             this.writerId = recruitBoard.getMember().getId();
@@ -173,8 +174,7 @@ public class BoardApiController {
             this.createdDate = recruitBoard.getCreatedDate();
             this.roleAssignments = roleAssignmentDtoList;
             this.scrapCount = recruitBoard.getScrapCount();
-
-
+            this.completeBoardId = recruitBoard.getWriteCompleteBoard().getId();
         }
 
     }
@@ -192,6 +192,8 @@ public class BoardApiController {
         private Integer profileIcon; // 글 쓴 사람 아이콘
         private Timestamp modifiedDate;//수정한 날짜
         private Timestamp createdDate; //만든 날짜
+        private Long completeBoardId; //개발 완료 글 id
+
         public NotDetailRecruitResponseDto(RecruitBoard recruitBoard){
             this.writerId = recruitBoard.getMember().getId();
             this.title = recruitBoard.getTitle();
@@ -204,9 +206,10 @@ public class BoardApiController {
             this.modifiedDate = recruitBoard.getModifiedDate();
             this.createdDate = recruitBoard.getCreatedDate();
             this.scrapCount = recruitBoard.getScrapCount();
-
+            if(recruitBoard.getWriteCompleteBoard() != null){
+                this.completeBoardId = recruitBoard.getWriteCompleteBoard().getId();
+            }
         }
-
     }
     @Data
     public class BoardListResponseDto {
@@ -250,6 +253,7 @@ public class BoardApiController {
         private Integer profileIcon; // 글 쓴 사람 아이콘
         private Timestamp createdDate; //만든 날짜
         private List<String> imageUrls = new ArrayList<>();
+        private Long recruitBoardId;
 
         public DetailCompleteResponseDto(CompleteBoard completeBoard) {
             this.writerId = completeBoard.getMember().getId();
@@ -259,6 +263,9 @@ public class BoardApiController {
             this.profileIcon = completeBoard.getMember().getProfileIcon();
             this.createdDate = completeBoard.getCreatedDate();
             this.scrapCount = completeBoard.getScrapCount();
+            if (completeBoard.getWriteRecruitBoard() != null){
+                this.recruitBoardId = completeBoard.getWriteRecruitBoard().getId();
+            }
             for(Image image : completeBoard.getImages()){
                 this.imageUrls.add(image.getUrl());
             }

--- a/src/main/java/com/won/myongjiCamp/model/board/CompleteBoard.java
+++ b/src/main/java/com/won/myongjiCamp/model/board/CompleteBoard.java
@@ -1,9 +1,6 @@
 package com.won.myongjiCamp.model.board;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -30,4 +27,9 @@ public class CompleteBoard extends Board {
         this.images.remove(image);
         image.setBoard(null);
     }
+
+    //모집완료 글
+    @OneToOne
+    @JoinColumn(name = "mapping_recruit_board_id")
+    private Board writeRecruitBoard;
 }

--- a/src/main/java/com/won/myongjiCamp/model/board/RecruitBoard.java
+++ b/src/main/java/com/won/myongjiCamp/model/board/RecruitBoard.java
@@ -31,5 +31,9 @@ public class RecruitBoard extends Board {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
+    // 개발완료 글
+    @OneToOne
+    @JoinColumn(name = "mapping_complete_board_id")
+    private Board writeCompleteBoard;
 
 }

--- a/src/main/java/com/won/myongjiCamp/repository/CompleteRepository.java
+++ b/src/main/java/com/won/myongjiCamp/repository/CompleteRepository.java
@@ -1,7 +1,11 @@
 package com.won.myongjiCamp.repository;
 
+import com.won.myongjiCamp.model.Member;
 import com.won.myongjiCamp.model.board.CompleteBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CompleteRepository extends JpaRepository<CompleteBoard,Long> {
+    List findByMember(Member member);
 }

--- a/src/main/java/com/won/myongjiCamp/service/ApplicationService.java
+++ b/src/main/java/com/won/myongjiCamp/service/ApplicationService.java
@@ -1,7 +1,5 @@
 package com.won.myongjiCamp.service;
 
-import com.won.myongjiCamp.config.auth.PrincipalDetail;
-import com.won.myongjiCamp.controller.api.ApplicationApiController;
 import com.won.myongjiCamp.dto.request.ApplicationDto;
 import com.won.myongjiCamp.exception.AlreadyProcessException;
 import com.won.myongjiCamp.model.Member;
@@ -17,22 +15,16 @@ import com.won.myongjiCamp.repository.ApplicationRepository;
 import com.won.myongjiCamp.repository.BoardRepository;
 import com.won.myongjiCamp.repository.RecruitRepository;
 import com.won.myongjiCamp.repository.RoleAssignmentRepository;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-import java.sql.Timestamp;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static com.won.myongjiCamp.model.application.ApplicationFinalStatus.PENDING;
 import static com.won.myongjiCamp.model.application.ApplicationStatus.*;
-import static org.apache.coyote.http11.Constants.a;
 
 @Transactional(readOnly = true)
 @Service
@@ -125,7 +117,7 @@ public class ApplicationService {
                     state.set(false);
                 }
             });
-            if (!state.get()) {
+            if (state.get()) {
                 board.setStatus(RecruitStatus.RECRUIT_COMPLETE);
             }
         }

--- a/src/main/java/com/won/myongjiCamp/service/BoardService.java
+++ b/src/main/java/com/won/myongjiCamp/service/BoardService.java
@@ -1,8 +1,11 @@
 package com.won.myongjiCamp.service;
 
 import com.won.myongjiCamp.dto.request.BoardSearchDto;
+import com.won.myongjiCamp.model.Member;
 import com.won.myongjiCamp.model.board.Board;
+import com.won.myongjiCamp.model.board.CompleteBoard;
 import com.won.myongjiCamp.repository.BoardRepository;
+import com.won.myongjiCamp.repository.CompleteRepository;
 import com.won.myongjiCamp.specification.BoardSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final CompleteRepository completeRepository;
 
     public Page<Board> searchBoards(BoardSearchDto requestDto) {
 
@@ -43,4 +48,8 @@ public class BoardService {
         return boardRepository.findAll(spec, pageable);
     }
 
+    public List<CompleteBoard> listMemberComplete(Member member) {
+        List boards = completeRepository.findByMember(member);
+        return boards;
+    }
 }

--- a/src/main/java/com/won/myongjiCamp/service/RecruitService.java
+++ b/src/main/java/com/won/myongjiCamp/service/RecruitService.java
@@ -5,6 +5,7 @@ import com.won.myongjiCamp.dto.RoleAssignmentDto;
 import com.won.myongjiCamp.model.Member;
 import com.won.myongjiCamp.model.application.Application;
 import com.won.myongjiCamp.model.board.Board;
+import com.won.myongjiCamp.model.board.CompleteBoard;
 import com.won.myongjiCamp.model.board.RecruitBoard;
 import com.won.myongjiCamp.model.board.RecruitStatus;
 import com.won.myongjiCamp.model.board.role.Role;
@@ -200,6 +201,8 @@ public class RecruitService {
     public void delete(Long id){
         RecruitBoard recruitBoard = recruitRepository.findById(id)
                 .orElseThrow(()->new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+        CompleteBoard completeBoard = (CompleteBoard) recruitBoard.getWriteCompleteBoard();
+        completeBoard.setWriteRecruitBoard(null);
         recruitRepository.delete(recruitBoard);
     }
 


### PR DESCRIPTION
## 💡 관련 이슈

#11 

## 📢 작업 내용

- board 엔티티에 자기 자신을 참조하여 recruit, complete을 담을 수 있는 속성을 추가하여 recruit 나 complete 글에서 매핑 된 board를 알 수 있게 수정
- 지원자가 최종 수락했을 때, 모집중에 있던 role이 꽉 차면 자동으로 모집 완료 글로 넘어가도록 수정
- 내가 쓴 complete 게시글 목록 api 추가 

## 🙏To Reviewers
x
## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
